### PR TITLE
feat(contact): add Strava profile link

### DIFF
--- a/br/index.html
+++ b/br/index.html
@@ -67,6 +67,7 @@
 <ul>
   <li><strong>GitHub</strong>: <a href="https://github.com/leandroh">@leandroh</a></li>
   <li><strong>LinkedIn</strong>: <a href="https://linkedin.com/in/leandroheuert">Leandro</a></li>
+  <li><strong>Strava</strong>: <a href="https://www.strava.com/athletes/20985328">Leandro</a></li>
 </ul>
 
   </main>

--- a/index.html
+++ b/index.html
@@ -67,6 +67,7 @@
 <ul>
   <li><strong>GitHub</strong>: <a href="https://github.com/leandroh">@leandroh</a></li>
   <li><strong>LinkedIn</strong>: <a href="https://linkedin.com/in/leandroheuert">Leandro</a></li>
+  <li><strong>Strava</strong>: <a href="https://www.strava.com/athletes/20985328">Leandro</a></li>
 </ul>
 
   </main>


### PR DESCRIPTION
## Problem

The contact section was missing a Strava profile link. Added it to both English and Portuguese versions of the site.

## Pre-landing review

No issues found.

## Test plan

- [ ] CI passes