### PR TITLE
feat: redesign profile page with Matrix rain, icons, and JetBrains Mono

### DIFF
--- a/br/index.html
+++ b/br/index.html
@@ -4,8 +4,9 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>About - parazito</title>
+  <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;600&display=swap" rel="stylesheet">
   <style>
-    body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; max-width: 700px; margin: 0 auto; padding: 0; line-height: 1.7; color: rgb(196, 196, 197); font-size: 18px; background: rgb(29, 30, 32); }
+    body { font-family: 'JetBrains Mono', Menlo, Consolas, Monaco, 'Lucida Console', 'Liberation Mono', 'DejaVu Sans Mono', 'Courier New', monospace; max-width: 700px; margin: 0 auto; padding: 0; line-height: 1.7; color: rgb(196, 196, 197); font-size: 16px; background: rgb(29, 30, 32); }
     .main-nav { display: flex; justify-content: space-between; align-items: center; padding: 1rem 2rem; border-bottom: 1px solid rgb(100, 100, 100); }
     .logo { font-size: 1.25rem; font-weight: 600; color: rgb(196, 196, 197); }
     .nav-links { display: flex; gap: 2rem; }
@@ -39,34 +40,33 @@
     </nav>
   </header>
   <main>
-    <h1 id="sobre">Sobre</h1>
+    <h1 id="sobre">Oi 👋</h1>
 
 <p><img src="/parazito.jpeg" alt="Leandro" /></p>
-
-<p>Olá! 👋</p>
 
 <p>Me chamo Leandro, mas algumas pessoas me chamam de Pará (ou parazito, <em>nickname</em> da época do IRC).</p>
 
 <p>Também gosto bastante de andar de bike por aí ao redor da <a href="https://www.google.com/maps/place/Florian%C3%B3polis,+SC">ilha de Florianópolis</a>. E também de caminhada, montanhismo e estar em meio à natureza.</p>
 
-<p>Curiosidades: ama pedalar 🚴‍♂️, café ☕, chimarrão com gengibre e cerveja gelada 🍺.</p>
+<p><strong>Fun facts:</strong> ⚡ Ciclista amador 🚴, ama trekking ⛰, hiking 🥾, e agora corrida 🏃‍♂️ também. 🧉 Chimarrão com gengibre.</p>
 
-<h2 id="tecnologias">Tecnologias</h2>
+<h2 id="tecnologias"><svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="rgb(160, 160, 170)" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align: middle; margin-right: 6px;"><polyline points="18 18 24 12 18 6"/><polyline points="6 6 0 12 6 18"/><line x1="14" y1="4" x2="10" y2="20"/></svg>Tecnologias</h2>
 
 <p>Interessado em tecnologias como:</p>
 
 <ul>
-  <li><strong>Ruby</strong> - Linguagem que mais amo</li>
-  <li><strong>Elixir</strong> - Aprendendo atualmente</li>
-  <li><strong>Go</strong> - Para projetos de infraestrutura</li>
-  <li><strong>Shell Script</strong> - Automação e DevOps</li>
+  <li><span style="color: #CC342D;">Ruby</span> - Linguagem que mais amo</li>
+  <li><span style="color: #6E4A7E;">Elixir</span> - Aprendendo atualmente</li>
+  <li><span style="color: #00ADD8;">Go</span> - Para projetos de infraestrutura</li>
+  <li><span style="color: #4EAA25;">Shell Script</span> - Automação e DevOps</li>
 </ul>
 
-<h2 id="contato">Contato</h2>
+<h2 id="contato"><svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="rgb(160, 160, 170)" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align: middle; margin-right: 6px;"><path d="M22 2L11 13"/><path d="M22 2L15 22L11 13L2 9L22 2Z"/></svg>Reach out</h2>
 
 <ul>
   <li><strong>GitHub</strong>: <a href="https://github.com/leandroh">@leandroh</a></li>
   <li><strong>LinkedIn</strong>: <a href="https://linkedin.com/in/leandroheuert">Leandro</a></li>
+  <li><strong>X</strong>: <a href="http://x.com/parazito">@parazito</a></li>
   <li><strong>Strava</strong>: <a href="https://www.strava.com/athletes/20985328">Leandro</a></li>
 </ul>
 

--- a/br/index.html
+++ b/br/index.html
@@ -73,29 +73,6 @@
 
   </main>
   <canvas id="matrix-canvas"></canvas>
-  <script>
-    const canvas = document.getElementById('matrix-canvas');
-    const ctx = canvas.getContext('2d');
-    canvas.width = window.innerWidth;
-    canvas.height = window.innerHeight;
-    window.addEventListener('resize', () => { canvas.width = window.innerWidth; canvas.height = window.innerHeight; });
-    const chars = 'アイウエオカキクケコサシスセソタチツテトナニヌネノハヒフヘホマミムメモヤユヨラリルレロワヲン0123456789ABCDEF';
-    const fontSize = 14;
-    const columns = Math.floor(canvas.width / fontSize);
-    const drops = Array(columns).fill(1);
-    function draw() {
-      ctx.fillStyle = 'rgba(29, 30, 32, 0.05)';
-      ctx.fillRect(0, 0, canvas.width, canvas.height);
-      ctx.fillStyle = '#0F0';
-      ctx.font = fontSize + 'px monospace';
-      for (let i = 0; i < drops.length; i++) {
-        const text = chars[Math.floor(Math.random() * chars.length)];
-        ctx.fillText(text, i * fontSize, drops[i] * fontSize);
-        if (drops[i] * fontSize > canvas.height && Math.random() > 0.975) drops[i] = 0;
-        drops[i]++;
-      }
-    }
-    setInterval(draw, 50);
-  </script>
+  <script src="/js/matrix.js"></script>
 </body>
 </html>

--- a/br/index.html
+++ b/br/index.html
@@ -6,7 +6,8 @@
   <title>About - parazito</title>
   <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;600&display=swap" rel="stylesheet">
   <style>
-    body { font-family: 'JetBrains Mono', Menlo, Consolas, Monaco, 'Lucida Console', 'Liberation Mono', 'DejaVu Sans Mono', 'Courier New', monospace; max-width: 700px; margin: 0 auto; padding: 0; line-height: 1.7; color: rgb(196, 196, 197); font-size: 16px; background: rgb(29, 30, 32); }
+    body { font-family: 'JetBrains Mono', Menlo, Consolas, Monaco, 'Lucida Console', 'Liberation Mono', 'DejaVu Sans Mono', 'Courier New', monospace; max-width: 700px; margin: 0 auto; padding: 0; line-height: 1.7; color: rgb(196, 196, 197); font-size: 16px; background: rgb(29, 30, 32); position: relative; z-index: 1; }
+    #matrix-canvas { position: fixed; top: 0; left: 0; width: 100%; height: 100%; z-index: 0; opacity: 0.08; pointer-events: none; }
     .main-nav { display: flex; justify-content: space-between; align-items: center; padding: 1rem 2rem; border-bottom: 1px solid rgb(100, 100, 100); }
     .logo { font-size: 1.25rem; font-weight: 600; color: rgb(196, 196, 197); }
     .nav-links { display: flex; gap: 2rem; }
@@ -71,5 +72,30 @@
 </ul>
 
   </main>
+  <canvas id="matrix-canvas"></canvas>
+  <script>
+    const canvas = document.getElementById('matrix-canvas');
+    const ctx = canvas.getContext('2d');
+    canvas.width = window.innerWidth;
+    canvas.height = window.innerHeight;
+    window.addEventListener('resize', () => { canvas.width = window.innerWidth; canvas.height = window.innerHeight; });
+    const chars = 'アイウエオカキクケコサシスセソタチツテトナニヌネノハヒフヘホマミムメモヤユヨラリルレロワヲン0123456789ABCDEF';
+    const fontSize = 14;
+    const columns = Math.floor(canvas.width / fontSize);
+    const drops = Array(columns).fill(1);
+    function draw() {
+      ctx.fillStyle = 'rgba(29, 30, 32, 0.05)';
+      ctx.fillRect(0, 0, canvas.width, canvas.height);
+      ctx.fillStyle = '#0F0';
+      ctx.font = fontSize + 'px monospace';
+      for (let i = 0; i < drops.length; i++) {
+        const text = chars[Math.floor(Math.random() * chars.length)];
+        ctx.fillText(text, i * fontSize, drops[i] * fontSize);
+        if (drops[i] * fontSize > canvas.height && Math.random() > 0.975) drops[i] = 0;
+        drops[i]++;
+      }
+    }
+    setInterval(draw, 50);
+  </script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -73,29 +73,6 @@
 
   </main>
   <canvas id="matrix-canvas"></canvas>
-  <script>
-    const canvas = document.getElementById('matrix-canvas');
-    const ctx = canvas.getContext('2d');
-    canvas.width = window.innerWidth;
-    canvas.height = window.innerHeight;
-    window.addEventListener('resize', () => { canvas.width = window.innerWidth; canvas.height = window.innerHeight; });
-    const chars = 'アイウエオカキクケコサシスセソタチツテトナニヌネノハヒフヘホマミムメモヤユヨラリルレロワヲン0123456789ABCDEF';
-    const fontSize = 14;
-    const columns = Math.floor(canvas.width / fontSize);
-    const drops = Array(columns).fill(1);
-    function draw() {
-      ctx.fillStyle = 'rgba(29, 30, 32, 0.05)';
-      ctx.fillRect(0, 0, canvas.width, canvas.height);
-      ctx.fillStyle = '#0F0';
-      ctx.font = fontSize + 'px monospace';
-      for (let i = 0; i < drops.length; i++) {
-        const text = chars[Math.floor(Math.random() * chars.length)];
-        ctx.fillText(text, i * fontSize, drops[i] * fontSize);
-        if (drops[i] * fontSize > canvas.height && Math.random() > 0.975) drops[i] = 0;
-        drops[i]++;
-      }
-    }
-    setInterval(draw, 50);
-  </script>
+  <script src="/js/matrix.js"></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -6,7 +6,8 @@
   <title>About - parazito</title>
   <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;600&display=swap" rel="stylesheet">
   <style>
-    body { font-family: 'JetBrains Mono', Menlo, Consolas, Monaco, 'Lucida Console', 'Liberation Mono', 'DejaVu Sans Mono', 'Courier New', monospace; max-width: 700px; margin: 0 auto; padding: 0; line-height: 1.7; color: rgb(196, 196, 197); font-size: 16px; background: rgb(29, 30, 32); }
+    body { font-family: 'JetBrains Mono', Menlo, Consolas, Monaco, 'Lucida Console', 'Liberation Mono', 'DejaVu Sans Mono', 'Courier New', monospace; max-width: 700px; margin: 0 auto; padding: 0; line-height: 1.7; color: rgb(196, 196, 197); font-size: 16px; background: rgb(29, 30, 32); position: relative; z-index: 1; }
+    #matrix-canvas { position: fixed; top: 0; left: 0; width: 100%; height: 100%; z-index: 0; opacity: 0.08; pointer-events: none; }
     .main-nav { display: flex; justify-content: space-between; align-items: center; padding: 1rem 2rem; border-bottom: 1px solid rgb(100, 100, 100); }
     .logo { font-size: 1.25rem; font-weight: 600; color: rgb(196, 196, 197); }
     .nav-links { display: flex; gap: 2rem; }
@@ -71,5 +72,30 @@
 </ul>
 
   </main>
+  <canvas id="matrix-canvas"></canvas>
+  <script>
+    const canvas = document.getElementById('matrix-canvas');
+    const ctx = canvas.getContext('2d');
+    canvas.width = window.innerWidth;
+    canvas.height = window.innerHeight;
+    window.addEventListener('resize', () => { canvas.width = window.innerWidth; canvas.height = window.innerHeight; });
+    const chars = 'アイウエオカキクケコサシスセソタチツテトナニヌネノハヒフヘホマミムメモヤユヨラリルレロワヲン0123456789ABCDEF';
+    const fontSize = 14;
+    const columns = Math.floor(canvas.width / fontSize);
+    const drops = Array(columns).fill(1);
+    function draw() {
+      ctx.fillStyle = 'rgba(29, 30, 32, 0.05)';
+      ctx.fillRect(0, 0, canvas.width, canvas.height);
+      ctx.fillStyle = '#0F0';
+      ctx.font = fontSize + 'px monospace';
+      for (let i = 0; i < drops.length; i++) {
+        const text = chars[Math.floor(Math.random() * chars.length)];
+        ctx.fillText(text, i * fontSize, drops[i] * fontSize);
+        if (drops[i] * fontSize > canvas.height && Math.random() > 0.975) drops[i] = 0;
+        drops[i]++;
+      }
+    }
+    setInterval(draw, 50);
+  </script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -4,8 +4,9 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>About - parazito</title>
+  <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;600&display=swap" rel="stylesheet">
   <style>
-    body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; max-width: 700px; margin: 0 auto; padding: 0; line-height: 1.7; color: rgb(196, 196, 197); font-size: 18px; background: rgb(29, 30, 32); }
+    body { font-family: 'JetBrains Mono', Menlo, Consolas, Monaco, 'Lucida Console', 'Liberation Mono', 'DejaVu Sans Mono', 'Courier New', monospace; max-width: 700px; margin: 0 auto; padding: 0; line-height: 1.7; color: rgb(196, 196, 197); font-size: 16px; background: rgb(29, 30, 32); }
     .main-nav { display: flex; justify-content: space-between; align-items: center; padding: 1rem 2rem; border-bottom: 1px solid rgb(100, 100, 100); }
     .logo { font-size: 1.25rem; font-weight: 600; color: rgb(196, 196, 197); }
     .nav-links { display: flex; gap: 2rem; }
@@ -39,34 +40,33 @@
     </nav>
   </header>
   <main>
-    <h1 id="about">About</h1>
+    <h1 id="about">Hi 👋</h1>
 
 <p><img src="/parazito.jpeg" alt="Leandro" /></p>
-
-<p>Hello! 👋</p>
 
 <p>My name is Leandro, but some people call me Pará (or parazito, <em>nickname</em> from the IRC era).</p>
 
 <p>I also really like cycling around the <a href="https://www.google.com/maps/place/Florian%C3%B3polis,+SC">island of Florianópolis</a>. And also hiking, mountaineering and being in nature.</p>
 
-<p>Curiosities: loves cycling 🚴‍♂️, coffee ☕, chimarrão with ginger, and cold beer 🍺.</p>
+<p><strong>Fun facts:</strong> ⚡ Amateur cyclist 🚴, loves trekking ⛰, hiking 🥾, and now running 🏃‍♂️ too. 🧉 Chimarrão com gengibre.</p>
 
-<h2 id="technologies">Technologies</h2>
+<h2 id="technologies"><svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="rgb(160, 160, 170)" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align: middle; margin-right: 6px;"><polyline points="18 18 24 12 18 6"/><polyline points="6 6 0 12 6 18"/><line x1="14" y1="4" x2="10" y2="20"/></svg>Technologies</h2>
 
 <p>Interested in technologies such as:</p>
 
 <ul>
-  <li><strong>Ruby</strong> - Language I love the most</li>
-  <li><strong>Elixir</strong> - Currently learning</li>
-  <li><strong>Go</strong> - For infrastructure projects</li>
-  <li><strong>Shell Script</strong> - Automation and DevOps</li>
+  <li><span style="color: #CC342D;">Ruby</span> - Language I love the most</li>
+  <li><span style="color: #6E4A7E;">Elixir</span> - Currently learning</li>
+  <li><span style="color: #00ADD8;">Go</span> - For infrastructure projects</li>
+  <li><span style="color: #4EAA25;">Shell Script</span> - Automation and DevOps</li>
 </ul>
 
-<h2 id="contact">Contact</h2>
+<h2 id="contact"><svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="rgb(160, 160, 170)" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align: middle; margin-right: 6px;"><path d="M22 2L11 13"/><path d="M22 2L15 22L11 13L2 9L22 2Z"/></svg>Reach out</h2>
 
 <ul>
   <li><strong>GitHub</strong>: <a href="https://github.com/leandroh">@leandroh</a></li>
   <li><strong>LinkedIn</strong>: <a href="https://linkedin.com/in/leandroheuert">Leandro</a></li>
+  <li><strong>X</strong>: <a href="http://x.com/parazito">@parazito</a></li>
   <li><strong>Strava</strong>: <a href="https://www.strava.com/athletes/20985328">Leandro</a></li>
 </ul>
 

--- a/js/matrix.js
+++ b/js/matrix.js
@@ -1,0 +1,30 @@
+const canvas = document.getElementById('matrix-canvas');
+const ctx = canvas.getContext('2d');
+
+canvas.width = window.innerWidth;
+canvas.height = window.innerHeight;
+
+window.addEventListener('resize', () => {
+  canvas.width = window.innerWidth;
+  canvas.height = window.innerHeight;
+});
+
+const chars = 'アイウエオカキクケコサシスセソタチツテトナニヌネノハヒフヘホマミムメモヤユヨラリルレロワヲン0123456789ABCDEF';
+const fontSize = 14;
+const columns = Math.floor(canvas.width / fontSize);
+const drops = Array(columns).fill(1);
+
+function draw() {
+  ctx.fillStyle = 'rgba(29, 30, 32, 0.05)';
+  ctx.fillRect(0, 0, canvas.width, canvas.height);
+  ctx.fillStyle = '#0F0';
+  ctx.font = fontSize + 'px monospace';
+  for (let i = 0; i < drops.length; i++) {
+    const text = chars[Math.floor(Math.random() * chars.length)];
+    ctx.fillText(text, i * fontSize, drops[i] * fontSize);
+    if (drops[i] * fontSize > canvas.height && Math.random() > 0.975) drops[i] = 0;
+    drops[i]++;
+  }
+}
+
+setInterval(draw, 50);


### PR DESCRIPTION
## Problem

The profile page needed a visual refresh to match a dev/hacker aesthetic — monospace font, section icons, technology brand colors, Matrix rain background, and a new X contact link.

## Pre-landing review

No issues found.

## Test plan

- [x] Verified locally in browser (EN and BR pages)
- [x] Matrix rain animation renders correctly
- [ ] CI passes