### PR TITLE
chore: update background color, remove matrix animation and tech colors

### DIFF
--- a/br/index.html
+++ b/br/index.html
@@ -6,8 +6,7 @@
   <title>About - parazito</title>
   <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;600&display=swap" rel="stylesheet">
   <style>
-    body { font-family: 'JetBrains Mono', Menlo, Consolas, Monaco, 'Lucida Console', 'Liberation Mono', 'DejaVu Sans Mono', 'Courier New', monospace; max-width: 700px; margin: 0 auto; padding: 0; line-height: 1.7; color: rgb(196, 196, 197); font-size: 16px; background: rgb(29, 30, 32); position: relative; z-index: 1; }
-    #matrix-canvas { position: fixed; top: 0; left: 0; width: 100%; height: 100%; z-index: 0; opacity: 0.08; pointer-events: none; }
+    body { font-family: 'JetBrains Mono', Menlo, Consolas, Monaco, 'Lucida Console', 'Liberation Mono', 'DejaVu Sans Mono', 'Courier New', monospace; max-width: 700px; margin: 0 auto; padding: 0; line-height: 1.7; color: rgb(196, 196, 197); font-size: 16px; background: #1a1b1e; }
     .main-nav { display: flex; justify-content: space-between; align-items: center; padding: 1rem 2rem; border-bottom: 1px solid rgb(100, 100, 100); }
     .logo { font-size: 1.25rem; font-weight: 600; color: rgb(196, 196, 197); }
     .nav-links { display: flex; gap: 2rem; }
@@ -49,17 +48,17 @@
 
 <p>Também gosto bastante de andar de bike por aí ao redor da <a href="https://www.google.com/maps/place/Florian%C3%B3polis,+SC">ilha de Florianópolis</a>. E também de caminhada, montanhismo e estar em meio à natureza.</p>
 
-<p><strong>Fun facts:</strong> ⚡ Ciclista amador 🚴, ama trekking ⛰, hiking 🥾, e agora corrida 🏃‍♂️ também. 🧉 Chimarrão com gengibre.</p>
+<p><strong>Fun facts:</strong> Ciclista amador, ama trekking, hiking, corrida e estar em meio à natureza. 🧉 Chimarrão com gengibre.</p>
 
 <h2 id="tecnologias"><svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="rgb(160, 160, 170)" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align: middle; margin-right: 6px;"><polyline points="18 18 24 12 18 6"/><polyline points="6 6 0 12 6 18"/><line x1="14" y1="4" x2="10" y2="20"/></svg>Tecnologias</h2>
 
 <p>Interessado em tecnologias como:</p>
 
 <ul>
-  <li><span style="color: #CC342D;">Ruby</span> - Linguagem que mais amo</li>
-  <li><span style="color: #6E4A7E;">Elixir</span> - Aprendendo atualmente</li>
-  <li><span style="color: #00ADD8;">Go</span> - Para projetos de infraestrutura</li>
-  <li><span style="color: #4EAA25;">Shell Script</span> - Automação e DevOps</li>
+  <li><strong>Ruby</strong> - Linguagem que mais amo</li>
+  <li><strong>Elixir</strong> - Aprendendo atualmente</li>
+  <li><strong>Go</strong> - Para projetos de infraestrutura</li>
+  <li><strong>Shell Script</strong> - Automação e DevOps</li>
 </ul>
 
 <h2 id="contato"><svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="rgb(160, 160, 170)" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align: middle; margin-right: 6px;"><path d="M22 2L11 13"/><path d="M22 2L15 22L11 13L2 9L22 2Z"/></svg>Reach out</h2>
@@ -72,7 +71,5 @@
 </ul>
 
   </main>
-  <canvas id="matrix-canvas"></canvas>
-  <script src="/js/matrix.js"></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -6,8 +6,7 @@
   <title>About - parazito</title>
   <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;600&display=swap" rel="stylesheet">
   <style>
-    body { font-family: 'JetBrains Mono', Menlo, Consolas, Monaco, 'Lucida Console', 'Liberation Mono', 'DejaVu Sans Mono', 'Courier New', monospace; max-width: 700px; margin: 0 auto; padding: 0; line-height: 1.7; color: rgb(196, 196, 197); font-size: 16px; background: rgb(29, 30, 32); position: relative; z-index: 1; }
-    #matrix-canvas { position: fixed; top: 0; left: 0; width: 100%; height: 100%; z-index: 0; opacity: 0.08; pointer-events: none; }
+    body { font-family: 'JetBrains Mono', Menlo, Consolas, Monaco, 'Lucida Console', 'Liberation Mono', 'DejaVu Sans Mono', 'Courier New', monospace; max-width: 700px; margin: 0 auto; padding: 0; line-height: 1.7; color: rgb(196, 196, 197); font-size: 16px; background: #1a1b1e; }
     .main-nav { display: flex; justify-content: space-between; align-items: center; padding: 1rem 2rem; border-bottom: 1px solid rgb(100, 100, 100); }
     .logo { font-size: 1.25rem; font-weight: 600; color: rgb(196, 196, 197); }
     .nav-links { display: flex; gap: 2rem; }
@@ -49,17 +48,17 @@
 
 <p>I also really like cycling around the <a href="https://www.google.com/maps/place/Florian%C3%B3polis,+SC">island of Florianópolis</a>. And also hiking, mountaineering and being in nature.</p>
 
-<p><strong>Fun facts:</strong> ⚡ Amateur cyclist 🚴, loves trekking ⛰, hiking 🥾, and now running 🏃‍♂️ too. 🧉 Chimarrão com gengibre.</p>
+<p><strong>Fun facts:</strong> Amateur cyclist, loves trekking, hiking, running and being in nature. 🧉 Chimarrão com gengibre.</p>
 
 <h2 id="technologies"><svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="rgb(160, 160, 170)" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align: middle; margin-right: 6px;"><polyline points="18 18 24 12 18 6"/><polyline points="6 6 0 12 6 18"/><line x1="14" y1="4" x2="10" y2="20"/></svg>Technologies</h2>
 
 <p>Interested in technologies such as:</p>
 
 <ul>
-  <li><span style="color: #CC342D;">Ruby</span> - Language I love the most</li>
-  <li><span style="color: #6E4A7E;">Elixir</span> - Currently learning</li>
-  <li><span style="color: #00ADD8;">Go</span> - For infrastructure projects</li>
-  <li><span style="color: #4EAA25;">Shell Script</span> - Automation and DevOps</li>
+  <li><strong>Ruby</strong> - Language I love the most</li>
+  <li><strong>Elixir</strong> - Currently learning</li>
+  <li><strong>Go</strong> - For infrastructure projects</li>
+  <li><strong>Shell Script</strong> - Automation and DevOps</li>
 </ul>
 
 <h2 id="contact"><svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="rgb(160, 160, 170)" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align: middle; margin-right: 6px;"><path d="M22 2L11 13"/><path d="M22 2L15 22L11 13L2 9L22 2Z"/></svg>Reach out</h2>
@@ -72,7 +71,5 @@
 </ul>
 
   </main>
-  <canvas id="matrix-canvas"></canvas>
-  <script src="/js/matrix.js"></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -34,7 +34,7 @@
       <span class="logo"><img src="/images/paralogo.png" alt="parazito logo" style="height: 64px; vertical-align: middle; margin-right: 12px;"> parazito</span>
       <div class="nav-links">
         <div class="lang-switch">
-          <a href="/br/">BRAZIL</a>
+          <a href="/br/">BRASIL</a>
         </div>
       </div>
     </nav>


### PR DESCRIPTION
## Problem

Simplify the page styling — switch to JetBrains-inspired background (#1a1b1e), remove Matrix rain animation and technology brand colors for a cleaner look. Also clean up fun facts emojis.

## Pre-landing review

No issues found.

## Test plan

- [x] Verified locally in browser (EN and BR pages)
- [ ] CI passes