### PR TITLE
site: clearer lang switcher labels

### DIFF
--- a/br/index.html
+++ b/br/index.html
@@ -41,7 +41,7 @@
       <div class="nav-links">
         
         <div class="lang-switch">
-          <a href="/en/">EN</a>
+          <a href="/en/">English</a>
         </div>
       </div>
     </nav>

--- a/br/posts/como-saber-imagem-ia/index.html
+++ b/br/posts/como-saber-imagem-ia/index.html
@@ -41,7 +41,7 @@
       <div class="nav-links">
         <a href="/br/" style="color: rgb(150, 150, 151); font-size: 0.875rem; margin-right: 1rem;">← início</a>
         <div class="lang-switch">
-          <a href="/en/">EN</a>
+          <a href="/en/">English</a>
         </div>
       </div>
     </nav>

--- a/en/index.html
+++ b/en/index.html
@@ -41,7 +41,7 @@
       <div class="nav-links">
         
         <div class="lang-switch">
-          <a href="/br/">BRAZIL</a>
+          <a href="/br/">Português</a>
         </div>
       </div>
     </nav>


### PR DESCRIPTION
## Problem

The lang switcher used `BRAZIL` (on EN pages) and `EN` (on PT pages). That mixed a country name with a language code, and `EN` is small/cryptic. Replacing with full target-language labels makes the switcher self-explanatory at a glance.

## Change

- EN page now shows **Português** in the switcher (clicking goes to `/br/`)
- PT page now shows **English** (clicking goes to `/en/`)

Each label is in the target language (Wikipedia / MDN convention) so a user who reads only that language can still identify it.

Generated by paradoc.

## Test plan

- [x] Local build shows new labels on `/en/`, `/br/`, `/br/posts/como-saber-imagem-ia/`
- [ ] CI passes
- [ ] Visual check on parazito.dev after deploy