### PR TITLE
site: clickable logo with soft hover

### DIFF
--- a/br/index.html
+++ b/br/index.html
@@ -8,7 +8,8 @@
   <style>
     body { font-family: 'JetBrains Mono', Menlo, Consolas, Monaco, 'Lucida Console', 'Liberation Mono', 'DejaVu Sans Mono', 'Courier New', monospace; max-width: 700px; margin: 0 auto; padding: 0; line-height: 1.7; color: rgb(196, 196, 197); font-size: 16px; background: #1a1b1e; }
     .main-nav { display: flex; justify-content: space-between; align-items: center; padding: 1rem 2rem; border-bottom: 1px solid rgb(100, 100, 100); }
-    .logo { font-size: 1.25rem; font-weight: 600; color: rgb(196, 196, 197); }
+    .logo { font-size: 1.25rem; font-weight: 600; color: rgb(196, 196, 197); text-decoration: none; transition: opacity 0.15s ease; }
+    .logo:hover { opacity: 0.75; text-decoration: none; }
     .nav-links { display: flex; gap: 2rem; align-items: center; }
     .nav-links a { color: rgb(150, 150, 151); text-decoration: none; font-size: 0.875rem; font-weight: 500; }
     .nav-links a:hover { color: rgb(196, 196, 197); }
@@ -37,7 +38,7 @@
 <body>
   <header>
     <nav class="main-nav">
-      <span class="logo"><img src="/images/paralogo.png" alt="parazito logo" style="height: 64px; vertical-align: middle; margin-right: 12px;"> parazito</span>
+      <a class="logo" href="/br/"><img src="/images/paralogo.png" alt="parazito logo" style="height: 64px; vertical-align: middle; margin-right: 12px;"> parazito</a>
       <div class="nav-links">
         
         <div class="lang-switch">

--- a/br/posts/como-saber-imagem-ia/index.html
+++ b/br/posts/como-saber-imagem-ia/index.html
@@ -8,7 +8,8 @@
   <style>
     body { font-family: 'JetBrains Mono', Menlo, Consolas, Monaco, 'Lucida Console', 'Liberation Mono', 'DejaVu Sans Mono', 'Courier New', monospace; max-width: 700px; margin: 0 auto; padding: 0; line-height: 1.7; color: rgb(196, 196, 197); font-size: 16px; background: #1a1b1e; }
     .main-nav { display: flex; justify-content: space-between; align-items: center; padding: 1rem 2rem; border-bottom: 1px solid rgb(100, 100, 100); }
-    .logo { font-size: 1.25rem; font-weight: 600; color: rgb(196, 196, 197); }
+    .logo { font-size: 1.25rem; font-weight: 600; color: rgb(196, 196, 197); text-decoration: none; transition: opacity 0.15s ease; }
+    .logo:hover { opacity: 0.75; text-decoration: none; }
     .nav-links { display: flex; gap: 2rem; align-items: center; }
     .nav-links a { color: rgb(150, 150, 151); text-decoration: none; font-size: 0.875rem; font-weight: 500; }
     .nav-links a:hover { color: rgb(196, 196, 197); }
@@ -37,7 +38,7 @@
 <body>
   <header>
     <nav class="main-nav">
-      <span class="logo"><img src="/images/paralogo.png" alt="parazito logo" style="height: 64px; vertical-align: middle; margin-right: 12px;"> parazito</span>
+      <a class="logo" href="/br/"><img src="/images/paralogo.png" alt="parazito logo" style="height: 64px; vertical-align: middle; margin-right: 12px;"> parazito</a>
       <div class="nav-links">
         <a href="/br/" style="color: rgb(150, 150, 151); font-size: 0.875rem; margin-right: 1rem;">← início</a>
         <div class="lang-switch">

--- a/en/index.html
+++ b/en/index.html
@@ -8,7 +8,8 @@
   <style>
     body { font-family: 'JetBrains Mono', Menlo, Consolas, Monaco, 'Lucida Console', 'Liberation Mono', 'DejaVu Sans Mono', 'Courier New', monospace; max-width: 700px; margin: 0 auto; padding: 0; line-height: 1.7; color: rgb(196, 196, 197); font-size: 16px; background: #1a1b1e; }
     .main-nav { display: flex; justify-content: space-between; align-items: center; padding: 1rem 2rem; border-bottom: 1px solid rgb(100, 100, 100); }
-    .logo { font-size: 1.25rem; font-weight: 600; color: rgb(196, 196, 197); }
+    .logo { font-size: 1.25rem; font-weight: 600; color: rgb(196, 196, 197); text-decoration: none; transition: opacity 0.15s ease; }
+    .logo:hover { opacity: 0.75; text-decoration: none; }
     .nav-links { display: flex; gap: 2rem; align-items: center; }
     .nav-links a { color: rgb(150, 150, 151); text-decoration: none; font-size: 0.875rem; font-weight: 500; }
     .nav-links a:hover { color: rgb(196, 196, 197); }
@@ -37,7 +38,7 @@
 <body>
   <header>
     <nav class="main-nav">
-      <span class="logo"><img src="/images/paralogo.png" alt="parazito logo" style="height: 64px; vertical-align: middle; margin-right: 12px;"> parazito</span>
+      <a class="logo" href="/en/"><img src="/images/paralogo.png" alt="parazito logo" style="height: 64px; vertical-align: middle; margin-right: 12px;"> parazito</a>
       <div class="nav-links">
         
         <div class="lang-switch">


### PR DESCRIPTION
## Problem

The logo and `parazito` text in the header were inert. Users on a post page or About had no quick way back to home without using the browser back button or the lang switcher.

## Change

- `<span class="logo">` → `<a class="logo">` pointing to the current language's home (`/en/` or `/br/`)
- No blue link color, no underline — same visual as before
- Hover: subtle `opacity: 0.75` with 150ms ease transition (no underline, no color change)

## Test plan

- [x] Local build shows logo as `<a class="logo" href="/en/"|"/br/">` on all pages
- [x] Hover visual is just a soft fade, no underline